### PR TITLE
Fix problem in remove when broken symlinks exist

### DIFF
--- a/src/deit/filesystem/Filesystem.php
+++ b/src/deit/filesystem/Filesystem.php
@@ -248,7 +248,7 @@ class Filesystem {
 		} else {
 
 			//remove the file if it exists
-			if (is_file($path)) {
+			if (is_file($path) || is_link($path)) {
 				if (!unlink($path)) {
 					throw new \Exception(sprintf('Unable to delete file "%s".', $path));
 				}

--- a/tests/deit/filesystem/FilesystemTest.php
+++ b/tests/deit/filesystem/FilesystemTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace deit\filesystem;
+
+/**
+ * Filesystem test
+ * @author Greg Bell <greg@bitwombat.com.au>
+ */
+
+class FilesystemTest extends \PHPUnit_Framework_TestCase {
+
+	public function rmdir_recursive($dir) {
+		foreach(scandir($dir) as $file) {
+			if ('.' === $file || '..' === $file) continue;
+			if (is_dir("$dir/$file")) rmdir_recursive("$dir/$file");
+			else unlink("$dir/$file");
+		}
+		rmdir($dir);
+	}
+
+	public function test_symlink_removal() {
+
+		$test_dir = 'tests/test-data/symlinks';
+		$test_link = $test_dir . '/points_nowhere';
+
+		if ( is_dir($test_dir) ) {
+			$this->rmdir_recursive( $test_dir );
+		}
+		mkdir( $test_dir );
+		symlink( "does_not_exist", $test_link );
+
+		$fs = new Filesystem();
+		$fs->remove( $test_dir );
+		$this->assertFalse ( is_link($test_link) || is_file($test_link) );
+
+	}
+}

--- a/tests/deit/filesystem/FinderTest.php
+++ b/tests/deit/filesystem/FinderTest.php
@@ -29,7 +29,7 @@ class FinderTest extends \PHPUnit_Framework_TestCase {
 		global $total_files;
 
 		$finder = new Finder('tests/test-data/bigtree');
-		
+
 		$this->assertEquals($total_files, count($finder->files()));
 
 		foreach ($finder->files()->named('#\.json$#') as $path) {
@@ -58,10 +58,8 @@ class FinderTest extends \PHPUnit_Framework_TestCase {
 
 	public function test_copy() {
 
-		$fs = new Filesystem();
-
-		$f = new Finder('tests/test-data/bigtree');
-		$f
+		$finder = new Finder('tests/test-data/bigtree');
+		$finder
 			->files()
 			->named('#\.json#')
 			->copyTo('tests/test-data-copy')


### PR DESCRIPTION
- Create failing test in FilesystemTest.php.   Broken symlink causes rmdir in
  remove to throw a warning and remove to throw an exception.
- Modify Filesystem.php to test for is_link when unlinking since is_file
  returns false for broken symlinks.
- Cleanup of FinderTest.php (unused Filesystem instances)
